### PR TITLE
Fix 8 ctypes struct layouts to match mtml_2.2.0.h

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -362,7 +362,7 @@ with mtmlVpuContext(device) as vpu:
     util = mtmlVpuGetUtilization(vpu)
     enc_cap, dec_cap = mtmlVpuGetCodecCapacity(vpu)
     print(f"VPU Clock: {clock} MHz")
-    print(f"Encode Util: {util.encodeUtil}%, Decode Util: {util.decodeUtil}%")
+    print(f"Encode Util: {util.encUtil}%, Decode Util: {util.decUtil}%")
     print(f"Codec Capacity: Enc={enc_cap}, Dec={dec_cap}")
 ```
 

--- a/examples/02_device_info.py
+++ b/examples/02_device_info.py
@@ -39,7 +39,6 @@ for i in range(mtmlLibraryCountDevice()):
     # PCI 信息
     pci = mtmlDeviceGetPciInfo(device)
     print(f"  PCI SBDF:   {pci.sbdf}")
-    print(f"  PCI Bus ID: {pci.busId}")
     print(f"  PCI 设备ID: {pci.pciDeviceId:#010x}")
     print(f"  PCIe 代数:  当前 Gen{pci.pciCurGen} / 最大 Gen{pci.pciMaxGen}")
     print(f"  PCIe 宽度:  当前 x{pci.pciCurWidth} / 最大 x{pci.pciMaxWidth}")
@@ -48,7 +47,7 @@ for i in range(mtmlLibraryCountDevice()):
     # PCIe 插槽信息
     try:
         slot = mtmlDeviceGetPcieSlotInfo(device)
-        print(f"  PCIe 插槽:  {slot.slotName} (type={slot.slotType})")
+        print(f"  PCIe 插槽:  {slot.slotName} (id={slot.slotId})")
     except MTMLError as e:
         print(f"  PCIe 插槽:  [不可用: {e}]")
 

--- a/examples/05_vpu_monitoring.py
+++ b/examples/05_vpu_monitoring.py
@@ -25,8 +25,8 @@ for i in range(mtmlLibraryCountDevice()):
 
             # 编解码利用率
             util = mtmlVpuGetUtilization(vpu)
-            print(f"  编码利用率:   {util.encodeUtil}%")
-            print(f"  解码利用率:   {util.decodeUtil}%")
+            print(f"  编码利用率:   {util.encUtil}%")
+            print(f"  解码利用率:   {util.decUtil}%")
 
             # 编解码容量
             enc_cap, dec_cap = mtmlVpuGetCodecCapacity(vpu)
@@ -41,8 +41,8 @@ for i in range(mtmlLibraryCountDevice()):
                 for s in enc_states:
                     if s.state == MTML_CODEC_SESSION_STATE_ACTIVE:
                         metrics = mtmlVpuGetEncoderSessionMetrics(vpu, s.sessionId)
-                        print(f"    编码会话 {s.sessionId}: {metrics.width}x{metrics.height}, "
-                              f"codec={metrics.codecType}, fps={metrics.fps}")
+                        print(f"    编码会话 {s.sessionId}: {metrics.hResolution}x{metrics.vResolution}, "
+                              f"codec={metrics.codecType}, fps={metrics.frameRate}")
                         break
             except MTMLError:
                 print(f"  活跃编码会话: [不可用]")
@@ -55,8 +55,8 @@ for i in range(mtmlLibraryCountDevice()):
                 for s in dec_states:
                     if s.state == MTML_CODEC_SESSION_STATE_ACTIVE:
                         metrics = mtmlVpuGetDecoderSessionMetrics(vpu, s.sessionId)
-                        print(f"    解码会话 {s.sessionId}: {metrics.width}x{metrics.height}, "
-                              f"codec={metrics.codecType}, fps={metrics.fps}")
+                        print(f"    解码会话 {s.sessionId}: {metrics.hResolution}x{metrics.vResolution}, "
+                              f"codec={metrics.codecType}, fps={metrics.frameRate}")
                         break
             except MTMLError:
                 print(f"  活跃解码会话: [不可用]")

--- a/examples/09_nvml_compatibility.py
+++ b/examples/09_nvml_compatibility.py
@@ -37,7 +37,6 @@ for i in range(device_count):
     # PCI 信息
     pci = pynvml.nvmlDeviceGetPciInfo(handle)
     print(f"  PCI SBDF: {pci.sbdf}")
-    print(f"  PCI BusId: {pci.busId}")
 
     # 显存信息 (返回 NVMLMemoryInfo dataclass)
     mem = pynvml.nvmlDeviceGetMemoryInfo(handle)
@@ -113,7 +112,7 @@ for i in range(device_count):
     try:
         remote_pci = pynvml.nvmlDeviceGetNvLinkRemotePciInfo(handle, 0)
         if remote_pci:
-            print(f"  NvLink/MtLink 链路0 远端 PCI: {remote_pci.busId}")
+            print(f"  NvLink/MtLink 链路0 远端 PCI: {remote_pci.sbdf}")
     except pynvml.NVMLError:
         pass
 

--- a/examples/10_device_paths.py
+++ b/examples/10_device_paths.py
@@ -38,7 +38,7 @@ for i in range(mtmlLibraryCountDevice()):
                 spec = mtmlDeviceGetDisplayInterfaceSpec(device, d)
                 type_name = disp_type_names.get(spec.type, f"Unknown({spec.type})")
                 print(f"    接口 {d}: {type_name}, "
-                      f"最大分辨率 {spec.maxResWidth}x{spec.maxResHeight}")
+                      f"最大分辨率 {spec.maxHoriRes}x{spec.maxVertRes}")
             except MTMLError as e:
                 print(f"    接口 {d}: [不可用: {e}]")
     except MTMLError as e:

--- a/examples/11_mpc_and_virtualization.py
+++ b/examples/11_mpc_and_virtualization.py
@@ -42,8 +42,8 @@ for i in range(mtmlLibraryCountDevice()):
         if profile_count > 0:
             profiles = mtmlDeviceGetSupportedMpcProfiles(device, profile_count)
             for p in profiles:
-                print(f"    ID={p.profileId}, 名称={p.name}, "
-                      f"显存={p.memSize / 1024**3:.1f}GB, 核心数={p.gpuCores}")
+                print(f"    ID={p.id}, 名称={p.name}, "
+                      f"显存={p.memorySizeMB / 1024:.1f}GB, 核心数={p.coreCount}")
     except MTMLError as e:
         print(f"  MPC 配置文件: [不可用: {e}]")
 
@@ -75,9 +75,8 @@ for i in range(mtmlLibraryCountDevice()):
         if supported > 0:
             virt_types = mtmlDeviceGetSupportedVirtTypes(device, supported)
             for vt in virt_types:
-                print(f"    ID={vt.id}, 名称={vt.name}, 类别={vt.deviceClass}")
-                print(f"      最大实例数={vt.maxInstances}, 显存={vt.memSize / 1024**3:.1f}GB, "
-                      f"核心数={vt.gpuCores}")
+                print(f"    ID={vt.id}, 名称={vt.name}, API={vt.api}")
+                print(f"      最大实例数={vt.maxInstances}, 显存={vt.frameBuffer / 1024:.1f}GB")
     except MTMLError as e:
         print(f"  支持的虚拟化类型: [不可用: {e}]")
 

--- a/pymtml.py
+++ b/pymtml.py
@@ -334,12 +334,14 @@ class c_mtmlMtLinkSpec_t(_PrintableStructure):
 
 
 class c_mtmlPciInfo_t(_PrintableStructure):
+    # Matches MtmlPciInfo in mtml_2.2.0.h (104 bytes).
     _fields_ = [
         ("sbdf", c_char * MTML_DEVICE_PCI_SBDF_BUFFER_SIZE),
         ("segment", c_uint),
         ("bus", c_uint),
         ("device", c_uint),
         ("pciDeviceId", c_uint),
+        ("pciSubsystemId", c_uint),
         ("busWidth", c_uint),
         ("pciMaxSpeed", c_float),
         ("pciCurSpeed", c_float),
@@ -347,8 +349,7 @@ class c_mtmlPciInfo_t(_PrintableStructure):
         ("pciCurWidth", c_uint),
         ("pciMaxGen", c_uint),
         ("pciCurGen", c_uint),
-        ("busId", c_char * MTML_DEVICE_PCI_BUS_ID_BUFFER_SIZE),
-        ("rsvd", c_uint * 6),
+        ("rsvd", c_int * 6),
     ]
 
 
@@ -365,8 +366,9 @@ class c_mtmlDeviceProperty_t(_PrintableStructure):
 
 ## PCI slot info structure
 class c_mtmlPciSlotInfo_t(_PrintableStructure):
+    # Matches MtmlPciSlotInfo in mtml_2.2.0.h (52 bytes).
     _fields_ = [
-        ("slotType", c_uint),
+        ("slotId", c_uint),
         ("slotName", c_char * MTML_DEVICE_SLOT_NAME_BUFFER_SIZE),
         ("rsvd", c_uint * 4),
     ]
@@ -374,38 +376,43 @@ class c_mtmlPciSlotInfo_t(_PrintableStructure):
 
 ## Display interface spec structure
 class c_mtmlDispIntfSpec_t(_PrintableStructure):
+    # Matches MtmlDispIntfSpec in mtml_2.2.0.h (48 bytes).
     _fields_ = [
         ("type", c_uint),
-        ("maxResWidth", c_uint),
-        ("maxResHeight", c_uint),
-        ("rsvd", c_uint * 4),
+        ("maxHoriRes", c_uint),
+        ("maxVertRes", c_uint),
+        ("maxRefreshRate", c_float),
+        ("rsvd", c_uint * 8),
     ]
 
 
 ## Virtualization type structure
 class c_mtmlVirtType_t(_PrintableStructure):
+    # Matches MtmlVirtType in mtml_2.2.0.h (136 bytes).
     _fields_ = [
         ("id", c_char * MTML_VIRT_TYPE_ID_BUFFER_SIZE),
-        ("deviceClass", c_char * MTML_VIRT_TYPE_CLASS_BUFFER_SIZE),
         ("name", c_char * MTML_VIRT_TYPE_NAME_BUFFER_SIZE),
+        ("api", c_char * MTML_VIRT_TYPE_API_BUFFER_SIZE),
+        ("horizontalResolution", c_uint),
+        ("verticalResolution", c_uint),
+        ("frameBuffer", c_uint),
+        ("maxEncodeNum", c_uint),
+        ("maxDecodeNum", c_uint),
         ("maxInstances", c_uint),
-        ("memSize", c_ulonglong),
-        ("gpuCores", c_uint),
-        ("maxResWidth", c_uint),
-        ("maxResHeight", c_uint),
-        ("apiType", c_char * MTML_VIRT_TYPE_API_BUFFER_SIZE),
-        ("encoderNum", c_uint),
-        ("decoderNum", c_uint),
-        ("rsvd", c_uint * 4),
+        ("maxVirtualDisplay", c_uint),
+        ("rsvd", c_int * 11),
     ]
 
 
 ## Codec utilization structure
 class c_mtmlCodecUtil_t(_PrintableStructure):
+    # Matches MtmlCodecUtil in mtml_2.2.0.h (24 bytes).
     _fields_ = [
-        ("encodeUtil", c_uint),
-        ("decodeUtil", c_uint),
-        ("rsvd", c_uint * 4),
+        ("util", c_uint),
+        ("period", c_uint),
+        ("encUtil", c_uint),
+        ("decUtil", c_uint),
+        ("rsvd", c_int * 2),
     ]
 
 
@@ -420,12 +427,17 @@ class c_mtmlCodecSessionState_t(_PrintableStructure):
 
 ## Codec session metrics structure
 class c_mtmlCodecSessionMetrics_t(_PrintableStructure):
+    # Matches MtmlCodecSessionMetrics in mtml_2.2.0.h (48 bytes).
     _fields_ = [
-        ("width", c_uint),
-        ("height", c_uint),
+        ("id", c_uint),
+        ("pid", c_uint),
+        ("hResolution", c_uint),
+        ("vResolution", c_uint),
+        ("frameRate", c_uint),
+        ("bitRate", c_uint),
+        ("latency", c_uint),
         ("codecType", c_uint),
-        ("fps", c_uint),
-        ("rsvd", c_uint * 4),
+        ("rsvd", c_int * 4),
     ]
 
 
@@ -441,23 +453,25 @@ class c_mtmlLogConfiguration_t(_PrintableStructure):
 
 ## MPC profile structure
 class c_mtmlMpcProfile_t(_PrintableStructure):
+    # Matches MtmlMpcProfile in mtml_2.2.0.h (88 bytes).
     _fields_ = [
-        ("profileId", c_uint),
+        ("id", c_uint),
+        ("coreCount", c_uint),
+        ("memorySizeMB", c_ulonglong),
         ("name", c_char * MTML_MPC_PROFILE_NAME_BUFFER_SIZE),
-        ("memSize", c_ulonglong),
-        ("gpuCores", c_uint),
-        ("rsvd", c_uint * 4),
+        ("rsvd", c_uint * 10),
     ]
 
 
 ## MPC configuration structure
 class c_mtmlMpcConfiguration_t(_PrintableStructure):
+    # Matches MtmlMpcConfiguration in mtml_2.2.0.h (196 bytes).
+    # profileId is signed int (-1 sentinel meaning "no profile in this slot").
     _fields_ = [
         ("id", c_uint),
         ("name", c_char * MTML_MPC_CONF_NAME_BUFFER_SIZE),
-        ("profileNum", c_uint),
-        ("profileIds", c_uint * MTML_MPC_CONF_MAX_PROF_NUM),
-        ("rsvd", c_uint * 4),
+        ("profileId", c_int * MTML_MPC_CONF_MAX_PROF_NUM),
+        ("rsvd", c_uint * 24),
     ]
 
 
@@ -863,10 +877,6 @@ def mtmlDeviceGetPciInfo(device):
     fn = _mtmlGetFunctionPointer("mtmlDeviceGetPciInfo")
     ret = fn(device, byref(c_pciinfo))
     _mtmlCheckReturn(ret)
-    # If busId is empty or invalid (contains non-printable chars), fill it with sbdf
-    bus_id = c_pciinfo.busId
-    if not bus_id or not bus_id[0].isalnum():
-        c_pciinfo.busId = c_pciinfo.sbdf
     return c_pciinfo
 
 @convertStrBytes
@@ -2038,7 +2048,7 @@ def nvmlDeviceGetEncoderUtilization(device):
     try:
         with mtmlVpuContext(device) as vpu:
             util = mtmlVpuGetUtilization(vpu)
-            return [util.encodeUtil, 0]  # samplingPeriodUs not available
+            return [util.encUtil, 0]  # samplingPeriodUs not available
     except MTMLError:
         return [0, 0]
 
@@ -2047,7 +2057,7 @@ def nvmlDeviceGetDecoderUtilization(device):
     try:
         with mtmlVpuContext(device) as vpu:
             util = mtmlVpuGetUtilization(vpu)
-            return [util.decodeUtil, 0]  # samplingPeriodUs not available
+            return [util.decUtil, 0]  # samplingPeriodUs not available
     except MTMLError:
         return [0, 0]
 

--- a/test_pymtml.py
+++ b/test_pymtml.py
@@ -77,13 +77,13 @@ class MtmlTestSuite:
         print_section(f"Device {device_idx} - PCI APIs")
 
         test_error("PCI Info", lambda: mtmlDeviceGetPciInfo(device))
-        # Verify busId is populated (should be filled from sbdf if empty)
+        # Verify sbdf (the canonical PCI bus identifier) is populated
         pci_info = mtmlDeviceGetPciInfo(device)
-        if pci_info.busId and pci_info.busId[0].isalnum():
-            print_result("PCI Info busId populated", pci_info.busId)
+        if pci_info.sbdf and pci_info.sbdf[0:1].isalnum():
+            print_result("PCI Info sbdf populated", pci_info.sbdf)
         else:
             print_result(
-                "PCI Info busId populated", "[FAIL: busId is empty or invalid]"
+                "PCI Info sbdf populated", "[FAIL: sbdf is empty or invalid]"
             )
         test_error("PCIe Slot Info", lambda: mtmlDeviceGetPcieSlotInfo(device))
 

--- a/test_pynvml.py
+++ b/test_pynvml.py
@@ -196,12 +196,12 @@ class PynvmlTestSuite:
         print_section("PCI APIs")
 
         test_api("nvmlDeviceGetPciInfo", lambda: pynvml.nvmlDeviceGetPciInfo(device))
-        # Verify busId is populated (should be filled from sbdf if empty)
+        # Verify sbdf (the canonical PCI bus identifier) is populated
         pci_info = pynvml.nvmlDeviceGetPciInfo(device)
-        if pci_info.busId and pci_info.busId[0].isalnum():
-            print_result("nvmlDeviceGetPciInfo busId populated", pci_info.busId)
+        if pci_info.sbdf and pci_info.sbdf[0:1].isalnum():
+            print_result("nvmlDeviceGetPciInfo sbdf populated", pci_info.sbdf)
         else:
-            print_result("nvmlDeviceGetPciInfo busId populated", "[FAIL: busId is empty or invalid]")
+            print_result("nvmlDeviceGetPciInfo sbdf populated", "[FAIL: sbdf is empty or invalid]")
         test_api(
             "nvmlDeviceGetPcieThroughput (TX)",
             lambda: pynvml.nvmlDeviceGetPcieThroughput(


### PR DESCRIPTION
### Summary

`pymtml.py` 中 8 个 `c_mtml*_t` 与 `mtml_2.2.0.h` 不一致。其中 4 个 Python 端 sizeof 比 C 端小，调用 MTML API 时 C 库会越界写入 Python 堆；剩下 4 个总大小恰好对得上但字段顺序/名字错位，导致按字段名读出的错误。


### 修改详情

| Struct | py < C? | 主要问题 |
|---|---|---|
| `c_mtmlPciInfo_t` | no | 缺 `pciSubsystemId`，凭空多出 `busId`；后续字段全部偏移 4B |
| `c_mtmlPciSlotInfo_t` | no | `slotType` → `slotId`（名字错） |
| `c_mtmlDispIntfSpec_t` | **yes (28<48)** | 缺 `maxRefreshRate`，`rsvd` 长度错 |
| `c_mtmlVirtType_t` | **yes** | 字段几乎全错 |
| `c_mtmlCodecUtil_t` | no | 缺 `util`/`period`，`encodeUtil`/`decodeUtil` 实际读到 `util`/`period` |
| `c_mtmlCodecSessionMetrics_t` | no | 缺 `id`/`pid`/`bitRate`/`latency` |
| `c_mtmlMpcProfile_t` | **yes (72<88)** | 字段顺序错，`rsvd` 太短 |
| `c_mtmlMpcConfiguration_t` | **yes (120<196)** | `profileIds` 长度错，类型应为 `int`（-1 哨兵） |

